### PR TITLE
Use git stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,4 @@ CS Student at NDHU experienced in:
   - BeautifulSoup, Pandas Dataframe, Jupyter Notebook
   - Bash shell scripting
 
-<!--
 [![Neil' GitHub stats](https://github-readme-stats-ashen-six-34.vercel.app/api?username=blackbird410&count_private=true&hide=issues&show_icons=true)](https://neil410.vercel.app)
--->


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. It removes a commented-out section containing a GitHub stats badge.